### PR TITLE
Collection of improvements for handling meta refresh & internal links

### DIFF
--- a/src/Tester.ts
+++ b/src/Tester.ts
@@ -261,7 +261,7 @@ export const Tester = function ({
       const parsedFolder = path.parse(path.resolve(folder));
       const normalizedFolder = `${parsedFolder.dir}/${parsedFolder.base}`;
 
-      const files = getHtmlFiles(`${normalizedFolder}`);
+      const files = getHtmlFiles(normalizedFolder);
 
       for (let i = 0; i < files.length; i++) {
         const file = files[i];

--- a/src/Tester.ts
+++ b/src/Tester.ts
@@ -207,6 +207,10 @@ export const Tester = function ({
         }
         result.aTags
           .filter((a) => !!a.href)
+          .map((a) => {
+            a.href = a.href.replace(new RegExp(`https?://${host}`), '');
+            return a;
+          })
           .filter((a) => !a.href.includes('http'))
           .filter((a) => !a.href.includes('mailto:'))
           .filter((a) => {
@@ -221,7 +225,7 @@ export const Tester = function ({
           .forEach((a) => internalLinks.push([a, this.currentUrl]));
         metaRefresh
           .filter((m) => m.content && m.content.includes('url='))
-          .map((m) => m.content.split('=')[1])
+          .map((m) => m.content.split('=')[1].replace(new RegExp(`https?://${host}`), ''))
           .filter((u) => !u.includes('http'))
           .filter((u) => {
             if (this.currentUrl !== '/') {

--- a/src/Tester.ts
+++ b/src/Tester.ts
@@ -208,6 +208,7 @@ export const Tester = function ({
         result.aTags
           .filter((a) => !!a.href)
           .filter((a) => !a.href.includes('http'))
+          .filter((a) => !a.href.includes('mailto:'))
           .filter((a) => {
             if (this.currentUrl !== '/') {
               return !a.href.endsWith(this.currentUrl);
@@ -215,7 +216,8 @@ export const Tester = function ({
             return true;
           })
           .filter((a) => a.href !== this.currentUrl)
-          .map((a) => a.href)
+          .map((a) => a.href.replace(/#.+$/, '')) // remove fragment
+          .filter(Boolean) // remove now empty fragment-only links
           .forEach((a) => internalLinks.push([a, this.currentUrl]));
         metaRefresh
           .filter((m) => m.content && m.content.includes('url='))
@@ -228,6 +230,8 @@ export const Tester = function ({
             return true;
           })
           .filter((u) => u !== this.currentUrl)
+          .map((u) => u.replace(/#.+$/, '')) // remove fragment
+          .filter(Boolean) // remove now empty fragment-only links
           .forEach((u) => internalLinks.push([u, this.currentUrl]));
       }
 

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -75,7 +75,7 @@ export const rules = [
           90,
           assert.strictEqual,
           titles[0].innerText,
-          titles[0].innerHTML,
+          titles[0].innerHTML.replace(/&amp;/g, '&'), // &amp; remains encoded
           'The title tag should not wrap other tags. (innerHTML and innerText should match)',
         );
         tester.test(100, assert.notStrictEqual, titles[0].innerText.length, 0, 'Title tags should not be empty');

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1,15 +1,7 @@
 import assert from 'assert';
 import { defaultPreferences } from './Tester';
 
-const cleanString = (str) =>
-  str
-    .toLowerCase()
-    .replace('|', '')
-    .replace('-', '')
-    .replace('.', '')
-    .replace(':', '')
-    .replace('!', '')
-    .replace('?', '');
+const cleanString = (str) => str.toLowerCase().replace(/[-|.,:!?…]/g, '');
 
 export const rules = [
   {

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -248,8 +248,6 @@ export const rules = [
 
           const matches = titleArr.filter((t) => compareArr.indexOf(t) !== -1);
 
-          if (matches.length < 1) console.log(titleArr, compareArr);
-
           tester.lint(70, assert.ok, matches.length >= 1, `H1 tag should have at least 1 word from your title tag.`);
         }
       } else {


### PR DESCRIPTION
I've found this tool really helpful and wanted to suggest some changes that have made a big difference for me. Happy for feedback or to split into multiple PRs if necessary.

* Better handling for pages containing `<meta http-equiv="refresh">`. Obviously not great for SEO, but a necessary evil of static sites, and this PR adds some specific checks to those pages.
* Removes URL fragments and `mailto:` links from the internal links set. Also recognises fully qualified (non-domain-relative) URLs as internal. 
* Watch out for `&`/`&amp;` in innerText/innerHTML comparison